### PR TITLE
fix: don't unset contract when onUpdate effect runs

### DIFF
--- a/dist/react-use-wavelet.js
+++ b/dist/react-use-wavelet.js
@@ -209,7 +209,6 @@ const useContract = (client, contractAddress, onUpdate, onLoad) => {
         consensusSocketRef.current.close(1000, 'closing consensusSocket');
       }
       setConsensusSocket(undefined);
-      setContract(undefined);
     };
   }, [client, contract, onUpdate]);
 

--- a/dist/react-use-wavelet.mjs
+++ b/dist/react-use-wavelet.mjs
@@ -203,7 +203,6 @@ const useContract = (client, contractAddress, onUpdate, onLoad) => {
         consensusSocketRef.current.close(1000, 'closing consensusSocket');
       }
       setConsensusSocket(undefined);
-      setContract(undefined);
     };
   }, [client, contract, onUpdate]);
 

--- a/dist/react-use-wavelet.umd.js
+++ b/dist/react-use-wavelet.umd.js
@@ -515,7 +515,6 @@
         }
 
         setConsensusSocket(undefined);
-        setContract(undefined);
       };
     }, [client, contract, onUpdate]);
     return [contract, error];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-wavelet",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Easily use Perlin Wavelet smart contracts in your React app",
   "src": "src/index.js",
   "main": "dist/react-use-wavelet.js",

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,6 @@ export const useContract = (client, contractAddress, onUpdate, onLoad) => {
         consensusSocketRef.current.close(1000, 'closing consensusSocket');
       }
       setConsensusSocket(undefined);
-      setContract(undefined);
     };
   }, [client, contract, onUpdate]);
 


### PR DESCRIPTION
Cleanup also runs before hooks get executed, so unsetting contract in the cleanup function for the onUpdate listener will kill the contract